### PR TITLE
Run using scipy's newest version

### DIFF
--- a/stablab/evans.py
+++ b/stablab/evans.py
@@ -1,6 +1,6 @@
 import numpy as np
 from scipy import linalg
-from scipy.misc import comb
+from scipy.special import comb
 from scipy.integrate import complex_ode
 from itertools import combinations
 from multiprocessing import Pool


### PR DESCRIPTION
scipy.misc.comb is now deprecated; we use scipy.special.comb